### PR TITLE
Mibdirs+

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -71,3 +71,9 @@ snmptt_trap_files:
   - /etc/snmp/snmptt.conf.hh3c_ui-man
 
 snmp_netdisco_mibs_repo: "https://github.com/netdisco/netdisco-mibs.git"
+
+mib_dir_list: false
+# Optionally define mibdirs to be added to snmp.conf, example:
+# mib_dir_list:
+#   - /var/lib/mibs/aruba_202005
+#   - /var/lib/mibs/hp_202003

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -72,8 +72,8 @@ snmptt_trap_files:
 
 snmp_netdisco_mibs_repo: "https://github.com/netdisco/netdisco-mibs.git"
 
-mib_dir_list: false
+nagios4_snmp_mib_dir_list: []
 # Optionally define mibdirs to be added to snmp.conf, example:
-# mib_dir_list:
+# nagios4_snmp_mib_dir_list:
 #   - /var/lib/mibs/aruba_202005
 #   - /var/lib/mibs/hp_202003

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -7,8 +7,11 @@ dependency:
     role-file: requirements.yml
 driver:
   name: docker
-lint:
-  name: yamllint
+lint: |
+  set -e
+  yamllint .
+  ansible-lint
+  flake8
 platforms:
 
   - name: ansible_test-01
@@ -50,13 +53,9 @@ provisioner:
   config_options:
     defaults:
       callback_whitelist: profile_tasks
-  lint:
-    name: ansible-lint
 
 scenario:
   name: default
 
 verifier:
   name: testinfra
-  lint:
-    name: flake8

--- a/molecule/local/molecule.yml
+++ b/molecule/local/molecule.yml
@@ -7,8 +7,11 @@ dependency:
     role-file: requirements.yml
 driver:
   name: docker
-lint:
-  name: yamllint
+lint: |
+  set -e
+  yamllint .
+  ansible-lint
+  flake8
 platforms:
 
   - name: ansible_test-01
@@ -63,13 +66,9 @@ provisioner:
           - name: client_to_remove
           - name: other_client_to_remove
         burp_server_port_per_operation_bool: true
-  lint:
-    name: ansible-lint
 
 scenario:
   name: local
 
 verifier:
   name: testinfra
-  lint:
-    name: flake8

--- a/templates/snmp.conf.j2
+++ b/templates/snmp.conf.j2
@@ -69,8 +69,8 @@ mibdirs +/var/lib/mibs/netdisco-mibs/rfc
 mibdirs +/var/lib/mibs/netdisco-mibs/vmware
 #mibdirs +/var/lib/mibs/netdisco-mibs/xirrus
 
-# Support additional mibdirs specified on mib_dir_list
-{% if mib_dir_list %}
-{% for l in mib_dir_list %}
+# Support additional mibdirs specified on nagios4_snmp_mib_dir_list
+{% if nagios4_snmp_mib_dir_list %}
+{% for l in nagios4_snmp_mib_dir_list %}
   mibdirs +{{ l }}{% endfor %}
 {% endif %}

--- a/templates/snmp.conf.j2
+++ b/templates/snmp.conf.j2
@@ -68,3 +68,9 @@ mibdirs +/var/lib/mibs/netdisco-mibs/rfc
 #mibdirs +/var/lib/mibs/netdisco-mibs/trapeze
 mibdirs +/var/lib/mibs/netdisco-mibs/vmware
 #mibdirs +/var/lib/mibs/netdisco-mibs/xirrus
+
+# Support additional mibdirs specified on mib_dir_list
+{% if mib_dir_list %}
+{% for l in mib_dir_list %}
+  mibdirs +{{ l }}{% endfor %}
+{% endif %}

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -10,7 +10,7 @@ snmptrap_dependencies:
   - snmp-mibs-downloader
   - snmp
   - git
-  - python-pip
+  - python3-pip
   - snmptrapd
 
 snmptrap_config_supervisor: false


### PR DESCRIPTION
Adding optional support for additional mibdirs.

The mibdirs need to be specified on the mib_dir_list variable (defaults to False to keep it from making any changes on snmp.conf).